### PR TITLE
Fix error caused by deleting channels with a reaction

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -93,6 +93,10 @@ export default class ReactionRole {
         });
       })
       .catch((e) => {
+        /* Check if the error is caused by message or channel being deleted, and ignore error if so */
+        if (reaction?.message?.deleted) {
+          return;
+        }
         console.error(
           "An error happened inside the addReaction handler of discordjs-reaction-role"
         );
@@ -125,6 +129,10 @@ export default class ReactionRole {
         });
       })
       .catch((e) => {
+        /* Check if the error is caused by message or channel being deleted, and ignore error if so */
+        if (reaction?.message?.deleted) {
+          return;
+        }
         console.error(
           "An error happened inside the removeReaction handler of discordjs-reaction-role"
         );


### PR DESCRIPTION
Some bots allows you to delete channels with a reaction. If that's done with a low enough lag, and a bot with reaction role permissions can see this happen, then the addReaction handler will throw an error. This fixes that.